### PR TITLE
fixup: update Ubuntu installation steps for proper execution

### DIFF
--- a/app/postman.md
+++ b/app/postman.md
@@ -6,7 +6,7 @@ sudo apt -y install libgconf2-4 [ubuntu 18.04.2]
 
 ### Download and Create Link
 ```sh
-wget https://dl.pstmn.io/download/latest/linux64 -O postman.tar.gz
+wget https://dl.pstmn.io/download/latest/linux64 -O Postman.tar.gz
 sudo tar -xzf Postman.tar.gz -C /opt/tools
 rm Postman.tar.gz
 sudo ln -s /opt/tools/Postman/Postman /usr/bin/Postman


### PR DESCRIPTION
Scenario: Running the installation steps on Ubuntu 22.04 results in the following error

![Screenshot from 2024-03-17 14-08-21](https://github.com/linux-bd/ubuntu/assets/26765117/98b14ba5-58df-443e-aaa1-17fbf4ebe867)


Proposed change:
change the output of wget to match with the further processing on case sensitive file systems
